### PR TITLE
Move the inspector window to the Tools Menu

### DIFF
--- a/addons/self_inspect/custom_tree_inspector.gd
+++ b/addons/self_inspect/custom_tree_inspector.gd
@@ -32,3 +32,7 @@ func _on_item_selected() -> void:
 	var tree_item = get_selected()
 	var node = tree_item.get_metadata(0)
 	EditorInterface.inspect_object(node)
+
+
+func _on_custom_tree_inspector_close_requested() -> void:
+	$"..".queue_free()

--- a/addons/self_inspect/custom_tree_inspector.tscn
+++ b/addons/self_inspect/custom_tree_inspector.tscn
@@ -2,16 +2,12 @@
 
 [ext_resource type="Script" path="res://addons/self_inspect/custom_tree_inspector.gd" id="1_myi58"]
 
-[node name="CustomTreeInspector" type="Control"]
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
+[node name="CustomTreeInspector" type="Window"]
+title = "Self Tree Inspector"
+initial_position = 1
+size = Vector2i(936, 510)
 
 [node name="Tree" type="Tree" parent="."]
-layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -20,7 +16,6 @@ grow_vertical = 2
 script = ExtResource("1_myi58")
 
 [node name="Button" type="Button" parent="."]
-layout_mode = 1
 anchors_preset = 3
 anchor_left = 1.0
 anchor_top = 1.0
@@ -32,5 +27,7 @@ grow_horizontal = 0
 grow_vertical = 0
 text = "Reload"
 
+[connection signal="close_requested" from="." to="." method="_on_close_requested"]
+[connection signal="close_requested" from="." to="Tree" method="_on_custom_tree_inspector_close_requested"]
 [connection signal="item_selected" from="Tree" to="Tree" method="_on_item_selected"]
 [connection signal="pressed" from="Button" to="Tree" method="_on_reload"]

--- a/addons/self_inspect/self_inspect.gd
+++ b/addons/self_inspect/self_inspect.gd
@@ -4,9 +4,11 @@ extends EditorPlugin
 var dock: Node
 
 func _enter_tree() -> void:
-	dock = preload("res://addons/self_inspect/custom_tree_inspector.tscn").instantiate()
-	add_control_to_dock(DOCK_SLOT_LEFT_UR, dock)
+	add_tool_menu_item("Self Tree Inspector", func(): 
+		dock = preload("res://addons/self_inspect/custom_tree_inspector.tscn").instantiate();
+		EditorInterface.get_base_control().add_child(dock)
+		)
 
 func _exit_tree() -> void:
-	remove_control_from_docks(dock)
+	remove_tool_menu_item("Self Tree Inspector")
 	dock.free()


### PR DESCRIPTION
This PR moves the inspector tool from the Godot left inspector menu (with the Scene and Import tabs) to its own window accessible under `Project > Tools > Self Tree Inspector`, which gives it a bigger, resizable window to work with.